### PR TITLE
interpipesink: Set sink pad's caps on new listener

### DIFF
--- a/gst/interpipe/gstinterpipesink.c
+++ b/gst/interpipe/gstinterpipesink.c
@@ -746,6 +746,20 @@ gst_inter_pipe_sink_add_listener (GstInterPipeINode * iface,
       if (!gst_inter_pipe_ilistener_set_caps (listener, sinkcaps))
         goto set_caps_failed;
     }
+  } else {
+    /* If src has no caps, set it to caps from sink pad */
+    GstEvent *capsev = gst_pad_get_sticky_event (GST_INTER_PIPE_SINK_PAD (sink),
+        GST_EVENT_CAPS, 0);
+    if (capsev) {
+      GstCaps *caps;
+      gst_event_parse_caps (capsev, &caps);
+      GST_INFO_OBJECT (sink, "Setting listener caps to %" GST_PTR_FORMAT, caps);
+      gst_inter_pipe_ilistener_set_caps (listener, caps);
+      gst_event_unref (capsev);
+    } else {
+      GST_INFO_OBJECT (sink,
+          "Cannot set caps, no caps event stuck on sink pad");
+    }
   }
 
   if (srccaps)


### PR DESCRIPTION
When new listeners are added, if they don't have caps, set them to
the sink pad's caps.
My application (GstRTSP server) adds listeners when the interpipesink
is already running, EVENT_CAPS never gets sent, and caps were never
being set on the interpipesrc.

This is a fix I mentioned in issue #5 