### PR TITLE
gstinterpipesrc: it should be live by default

### DIFF
--- a/gst/interpipe/gstinterpipesrc.c
+++ b/gst/interpipe/gstinterpipesrc.c
@@ -63,6 +63,8 @@ enum
   PROP_ACCEPT_EOS_EVENT
 };
 
+#define DEFAULT_PROP_IS_LIVE TRUE
+
 static void gst_inter_pipe_src_set_property (GObject * object, guint prop_id,
     const GValue * value, GParamSpec * pspec);
 static void gst_inter_pipe_src_get_property (GObject * object, guint prop_id,
@@ -212,6 +214,10 @@ gst_inter_pipe_src_init (GstInterPipeSrc * src)
   src->enable_sync = TRUE;
   src->accept_events = TRUE;
   src->accept_eos_event = TRUE;
+
+#if DEFAULT_PROP_IS_LIVE
+  gst_base_src_set_live (GST_BASE_SRC (src), DEFAULT_PROP_IS_LIVE);
+#endif
 }
 
 static void


### PR DESCRIPTION
since otherwise it can't preroll
just because it accepts buffers only in playing state
but can't go to playing state without accepting at least one buffer.

for reference: https://github.com/RidgeRun/gst-interpipe/blob/master/gst/interpipe/gstinterpipesrc.c#L605