### PR TITLE
Not send re-negotiation event when not needed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@ dnl please read gstreamer/docs/random/autotools before changing this file
 dnl initialize autoconf
 dnl releases only do -Wall, git and prerelease does -Werror too
 dnl use a three digit version number for releases, and four for git/pre
-AC_INIT([GstInterpipe],[1.1.0],
+AC_INIT([GstInterpipe],[1.1.1],
 	[http://www.github.com/RidgeRun/gst-interpipe-1.0],
 	[gst-interpipe],
 	[http://developer.ridgerun.com/wiki/index.php?title=GstInterpipe])

--- a/gst-interpipe.doap
+++ b/gst-interpipe.doap
@@ -32,6 +32,16 @@ GstInterpipe is a plug-in with two elements which allow the communication betwee
 
 <release>
   <Version>
+  <revision>1.1.1</revision>
+   <branch>master</branch>
+   <name></name>
+   <created>2020-04-28</created>
+   <file-release rdf:resource="" />
+  </Version>
+</release>
+
+<release>
+  <Version>
   <revision>1.1.0</revision>
    <branch>master</branch>
    <name></name>

--- a/gst/interpipe/gstinterpipesink.c
+++ b/gst/interpipe/gstinterpipesink.c
@@ -746,8 +746,10 @@ gst_inter_pipe_sink_add_listener (GstInterPipeINode * iface,
 
     has_listeners = 0 != g_hash_table_size (listeners);
 
-    if (!sink->caps_negotiated && !has_listeners) {
-      if (!gst_pad_push_event (GST_INTER_PIPE_SINK_PAD (sink),
+    if (!sink->caps_negotiated && !has_listeners
+	&& !gst_caps_is_equal (srccaps, sinkcaps)) {
+
+	if (!gst_pad_push_event (GST_INTER_PIPE_SINK_PAD (sink),
               gst_event_new_reconfigure ()))
         goto reconfigure_event_error;
 


### PR DESCRIPTION
When there are no listeners, and the caps haven't changed, the re-negotiation caps event shouldn't be sent upstream. This change avoids this event to be sent if the caps haven't changed. 