### PR TITLE
interpipesrc: clean appsrc caps at stop

### DIFF
--- a/gst/interpipe/gstinterpipesrc.c
+++ b/gst/interpipe/gstinterpipesrc.c
@@ -404,16 +404,21 @@ gst_inter_pipe_src_stop (GstBaseSrc * base)
   GstBaseSrcClass *basesrc_class;
   GstInterPipeSrc *src;
   GstInterPipeIListener *listener;
+  GstAppSrc *appsrc;
 
   basesrc_class = GST_BASE_SRC_CLASS (gst_inter_pipe_src_parent_class);
   src = GST_INTER_PIPE_SRC (base);
   listener = GST_INTER_PIPE_ILISTENER (src);
+  appsrc = GST_APP_SRC (src);
 
   if (src->listening) {
     GST_INFO_OBJECT (src, "Removing listener from node %s", src->listen_to);
     gst_inter_pipe_leave_node (listener);
     src->listening = FALSE;
   }
+
+  GST_INFO_OBJECT (src, "Cleaning appsrc caps");
+  gst_app_src_set_caps (appsrc, NULL);
 
   return basesrc_class->stop (base);
 }


### PR DESCRIPTION
This cleans the appsrc caps at stop state, cleaning
the negotiated state so when the pipeline is restarted
it can initiate a clean negotiation process.