### PR TITLE
add event type & source to "multiple listeners" warning

### DIFF
--- a/gst/interpipe/gstinterpipeinode.c
+++ b/gst/interpipe/gstinterpipeinode.c
@@ -68,14 +68,15 @@ gst_inter_pipe_inode_remove_listener (GstInterPipeINode * self,
 }
 
 gboolean
-gst_inter_pipe_inode_receive_event (GstInterPipeINode * self, GstEvent * event)
+gst_inter_pipe_inode_receive_event (GstInterPipeINode * self, GstInterPipeIListener * listener, GstEvent * event)
 {
   GstInterPipeINodeInterface *iface;
 
   g_return_val_if_fail (GST_INTER_PIPE_IS_INODE (self), FALSE);
+  g_return_val_if_fail (listener != NULL, FALSE);
 
   iface = GST_INTER_PIPE_INODE_GET_IFACE (self);
   g_return_val_if_fail (iface->receive_event != NULL, FALSE);
 
-  return iface->receive_event (self, event);
+  return iface->receive_event (self, listener, event);
 }

--- a/gst/interpipe/gstinterpipeinode.h
+++ b/gst/interpipe/gstinterpipeinode.h
@@ -64,7 +64,7 @@ struct _GstInterPipeINodeInterface
 
   gboolean (* add_listener) (GstInterPipeINode *iface, GstInterPipeIListener * listener);
   gboolean (* remove_listener) (GstInterPipeINode *iface, GstInterPipeIListener * listener);
-  gboolean (* receive_event) (GstInterPipeINode *iface, GstEvent *event);
+  gboolean (* receive_event) (GstInterPipeINode *iface, GstInterPipeIListener * listener, GstEvent *event);
 };
 
 /**
@@ -102,7 +102,7 @@ gboolean gst_inter_pipe_inode_remove_listener (GstInterPipeINode *iface, GstInte
  *
  * Returns: True if the node is able to receive the event, False otherwise.
  */
-gboolean gst_inter_pipe_inode_receive_event (GstInterPipeINode *iface, GstEvent *event);
+gboolean gst_inter_pipe_inode_receive_event (GstInterPipeINode *iface, GstInterPipeIListener * listener, GstEvent *event);
 
 GType gst_inter_pipe_inode_get_type (void);
 

--- a/gst/interpipe/gstinterpipesink.c
+++ b/gst/interpipe/gstinterpipesink.c
@@ -75,7 +75,7 @@ static gboolean gst_inter_pipe_sink_add_listener (GstInterPipeINode * iface,
 static gboolean gst_inter_pipe_sink_remove_listener (GstInterPipeINode * iface,
     GstInterPipeIListener * listener);
 static gboolean gst_inter_pipe_sink_receive_event (GstInterPipeINode * iface,
-    GstEvent * event);
+    GstInterPipeIListener * listener, GstEvent * event);
 static GstCaps *gst_inter_pipe_sink_get_caps (GstBaseSink * base,
     GstCaps * filter);
 static gboolean gst_inter_pipe_sink_set_caps (GstBaseSink * base,
@@ -870,7 +870,7 @@ not_registered:
 }
 
 static gboolean
-gst_inter_pipe_sink_receive_event (GstInterPipeINode * iface, GstEvent * event)
+gst_inter_pipe_sink_receive_event (GstInterPipeINode * iface, GstInterPipeIListener * listener, GstEvent * event)
 {
   GstInterPipeSink *self;
   GHashTable *listeners;
@@ -889,8 +889,11 @@ gst_inter_pipe_sink_receive_event (GstInterPipeINode * iface, GstEvent * event)
 
 multiple_listeners:
   {
-    GST_WARNING_OBJECT (self, "Could not send event upstream, "
-        "more than one listener is connected");
+    gchar* evtype = g_ascii_strup(GST_EVENT_TYPE_NAME(event), -1);
+    GST_WARNING_OBJECT (self,
+        "Could not send %s event from %s upstream, more than one listener is connected",
+        evtype, gst_inter_pipe_ilistener_get_name(listener));
+    g_free(evtype);
     return FALSE;
   }
 }

--- a/gst/interpipe/gstinterpipesrc.c
+++ b/gst/interpipe/gstinterpipesrc.c
@@ -435,7 +435,7 @@ gst_inter_pipe_src_event (GstBaseSrc * base, GstEvent * event)
         GST_EVENT_TYPE_NAME (event));
 
     if (node) {
-      gst_inter_pipe_inode_receive_event (node, gst_event_ref (event));
+      gst_inter_pipe_inode_receive_event (node, GST_INTER_PIPE_ILISTENER (src), gst_event_ref (event));
     } else
       GST_WARNING_OBJECT (src, "Node doesn't exist, event won't be forwarded");
   }


### PR DESCRIPTION
The "Could not send event upstream, more than one listener is connected" warnings are common, spammy and often don't represent a problem... IMO it would be handy to at least log the event type, and the listener it came from.