### PR TITLE
interpipesink: Initialize forward-events in false

### DIFF
--- a/gst/interpipe/gstinterpipesink.c
+++ b/gst/interpipe/gstinterpipesink.c
@@ -204,7 +204,7 @@ gst_inter_pipe_sink_init (GstInterPipeSink * sink)
   sink->node_name = NULL;
   sink->listeners = g_hash_table_new (g_direct_hash, g_direct_equal);
   sink->forward_eos = FALSE;
-  sink->forward_events = TRUE;
+  sink->forward_events = FALSE;
   sink->last_buffer_timestamp = 0;
 
   g_mutex_init (&sink->listeners_mutex);


### PR DESCRIPTION
This change fixes the mismatch between the gst-inspect documentation and the value of the property itself.