### PR TITLE
Fix a memory leak for g_strdup

### DIFF
--- a/gst/interpipe/gstinterpipesrc.c
+++ b/gst/interpipe/gstinterpipesrc.c
@@ -417,6 +417,8 @@ gst_inter_pipe_src_stop (GstBaseSrc * base)
     GST_INFO_OBJECT (src, "Removing listener from node %s", src->listen_to);
     gst_inter_pipe_leave_node (listener);
     src->listening = FALSE;
+    g_free (src->listen_to);
+    src->listen_to = NULL;
   }
 
   return basesrc_class->stop (base);


### PR DESCRIPTION
An old listen_to string is freed when it is newly set via the set_property invocation, but we lose opportunity to free it once the
plugin goes to the finalization because the context is freed at that time. The node registration itself is removed when the plugin stops, so it should be freed in the stop method.
