### PR TITLE
Fix segment handling in interpipesrc

### DIFF
--- a/gst/interpipe/gstinterpipesrc.c
+++ b/gst/interpipe/gstinterpipesrc.c
@@ -671,6 +671,7 @@ gst_inter_pipe_src_push_buffer (GstInterPipeIListener * iface,
         GST_TIME_ARGS (GST_BUFFER_PTS (buffer)));
   } else if (GST_INTER_PIPE_SRC_RESTART_TIMESTAMP == src->stream_sync) {
     /* Remove the incoming timestamp to be generated according this basetime */
+    buffer = gst_buffer_make_writable (buffer);
     GST_BUFFER_PTS (buffer) = GST_CLOCK_TIME_NONE;
     GST_BUFFER_DTS (buffer) = GST_CLOCK_TIME_NONE;
   }

--- a/gst/interpipe/gstinterpipesrc.c
+++ b/gst/interpipe/gstinterpipesrc.c
@@ -473,13 +473,14 @@ gst_inter_pipe_src_create (GstBaseSrc * base, guint64 offset, guint size,
       "Dequeue buffer %p with timestamp (PTS) %" GST_TIME_FORMAT, *buf,
       GST_TIME_ARGS (GST_BUFFER_PTS (*buf)));
 
-  if (!g_queue_is_empty (src->pending_serial_events)) {
+  while (!g_queue_is_empty (src->pending_serial_events)) {
     guint curr_bytes;
     /*Pending Serial Events Queue */
     serial_event = g_queue_peek_head (src->pending_serial_events);
 
     GST_DEBUG_OBJECT (src,
-        "Got event with timestamp %" GST_TIME_FORMAT,
+        "Got event %s with timestamp %" GST_TIME_FORMAT,
+        GST_EVENT_TYPE_NAME (serial_event),
         GST_TIME_ARGS (GST_EVENT_TIMESTAMP (serial_event)));
 
     curr_bytes = gst_app_src_get_current_level_bytes (GST_APP_SRC (src));
@@ -495,6 +496,7 @@ gst_inter_pipe_src_create (GstBaseSrc * base, guint64 offset, guint size,
       GST_DEBUG_OBJECT (src, "Event %s timestamp is greater than the "
           "buffer timestamp, can't send serial event yet",
           GST_EVENT_TYPE_NAME (serial_event));
+          break;
     }
   }
 

--- a/gst/interpipe/gstinterpipesrc.c
+++ b/gst/interpipe/gstinterpipesrc.c
@@ -491,7 +491,22 @@ gst_inter_pipe_src_create (GstBaseSrc * base, guint64 offset, guint size,
           GST_EVENT_TYPE_NAME (serial_event));
 
       serial_event = g_queue_pop_head (src->pending_serial_events);
-      gst_pad_push_event (srcpad, serial_event);
+      
+      if (GST_EVENT_TYPE (serial_event) == GST_EVENT_SEGMENT) {
+          const GstSegment *segment = NULL;
+
+          gst_event_parse_segment (serial_event, &segment);
+          g_assert (segment != NULL);
+
+          GST_DEBUG_OBJECT (src,
+              "Update new segment %" GST_PTR_FORMAT, serial_event);
+          if (!gst_base_src_new_segment (base, segment)) {
+            GST_ERROR_OBJECT (src,
+                "Couldn't set new segment %" GST_PTR_FORMAT, serial_event);
+          }
+      } else {
+          gst_pad_push_event (srcpad, serial_event);
+      }
     } else {
       GST_DEBUG_OBJECT (src, "Event %s timestamp is greater than the "
           "buffer timestamp, can't send serial event yet",


### PR DESCRIPTION
It was missing something like what is done in appsrc->create(): https://gitlab.freedesktop.org/gstreamer/gst-plugins-base/-/blob/master/gst-libs/gst/app/gstappsrc.c#L1676

Related to #96