### PR TITLE
Only require gstreamer-check dependency when building tests

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -16,7 +16,6 @@ gst_interpipes_version_is_dev = gst_interpipes_version_minor % 2 == 1 and gst_in
 
 # Find external dependencies
 gst_app_dep = dependency('gstreamer-app-1.0', version : '>=1.0.5')
-gst_check_dep = dependency('gstreamer-check-1.0', version : '>=1.0.5')
 
 # Define compiler args and include directories
 gst_c_args = ['-DHAVE_CONFIG_H']

--- a/tests/check/meson.build
+++ b/tests/check/meson.build
@@ -21,6 +21,7 @@ test_defines = [
   '-DTESTFILE="' + meson.current_source_dir() + '/meson.build"',
 ]
 
+gst_check_dep = dependency('gstreamer-check-1.0', version : '>=1.0.5')
 # Define test dependencies
 test_deps=[gst_app_dep, gst_check_dep, interpipes_dep]
 


### PR DESCRIPTION
We don't build the `gstreamer-check` dependency in our custom builds, so building `gst-interpipe` with tests disabled fails because of the dependency in the top level.

Moving this dependency into the tests `meson.build` overcomes this, and this PR fixes that