### PR TITLE
Add element error when caps doesn't intersect

### DIFF
--- a/gst/interpipe/gstinterpipesink.c
+++ b/gst/interpipe/gstinterpipesink.c
@@ -451,6 +451,7 @@ gst_inter_pipe_sink_get_caps (GstBaseSink * base, GstCaps * filter)
   if (!sink->caps_negotiated || gst_caps_is_empty (sink->caps_negotiated)) {
     GST_ERROR_OBJECT (sink,
         "Failed to obtain an intersection between upstream elements and listeners");
+    GST_ELEMENT_ERROR(sink, STREAM, FAILED, (NULL), ("Caps intersection error"));
     goto nointersection;
   }
 


### PR DESCRIPTION
Report the caps intersection error into the GstBus so that upstream elements and listeners can recover from it