### PR TITLE
Clarify that the interpipes run in the same process

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # GstInterpipe 1.0
 GstInterpipe is a Gstreamer plug-in that allows communication between
-two independent pipelines. The plug-in consists of two elements:
+two independent pipelines within the same process.
+
+The plug-in consists of two elements:
 - interpipesink
 - interpipesrc
 


### PR DESCRIPTION
There is common confusion about using `gst-interpipe` that the pipelines are running in the same process. 

I watched the demo video at https://vimeo.com/240547523 and this was clarified with one of the first question asked (around the 32:30 mark).

Even though I have used `gst-launch-1.0` for various testing, I was not aware that it can run multiple pipelines at once like the examples given at https://developer.ridgerun.com/wiki/index.php/GstInterpipe_-_Buffer_Forwarding.

When you are familiar with the implementation details, then it becomes obvious that the pipelines are running in the same process. However, media applications are often distributed and since `gst-interpipe` helps with a variety of things, the way it is described and the way people think about using it could make it seem like it would work with pipelines running in different processes. 

Also, the diagrams don't make it obvious that everything is running in the same process because similar diagrams could be drawn in situations where pipelines are running in different processes. For example, one process streaming as a server and another process on a different machine running as a client.