### PR TITLE
Send EOS to appsrc when stopping if block enabled to prevent deadlock

### DIFF
--- a/gst/interpipe/gstinterpipesrc.c
+++ b/gst/interpipe/gstinterpipesrc.c
@@ -416,11 +416,19 @@ gst_inter_pipe_src_stop (GstBaseSrc * base)
 {
   GstBaseSrcClass *basesrc_class;
   GstInterPipeSrc *src;
+  GstAppSrc *appsrc;
   GstInterPipeIListener *listener;
+  gboolean blocking;
 
   basesrc_class = GST_BASE_SRC_CLASS (gst_inter_pipe_src_parent_class);
   src = GST_INTER_PIPE_SRC (base);
+  appsrc = GST_APP_SRC (src);
   listener = GST_INTER_PIPE_ILISTENER (src);
+
+  g_object_get(G_OBJECT(appsrc), "block", &blocking, NULL);
+  if (blocking) {
+    gst_app_src_end_of_stream(GST_APP_SRC(appsrc));
+  }
 
   if (src->listening) {
     GST_INFO_OBJECT (src, "Removing listener from node %s", src->listen_to);


### PR DESCRIPTION
I experience a deadlock when stopping a pipeline using interpipesrc with block=TRUE. 

This happens because: 

- Interpipesink receives a buffer, blocks the listeners_mutex, and iterates its listeners to forward the buffer to each one.
- Interpipesrc receives the buffer and tries to push it downstream (gst_app_src_push_buffer). When the block property is set to true, this call blocks until free space is available. 
- As the pipeline is indeed stopping, the buffer will never be consumed by the elements downstream.
- The push buffer call never returns. The listeners_mutex was acquired but never released.
- From inside "gst_inter_pipe_src_stop", the call to "gst_inter_pipe_leave_node" to remove itself from the listeners of the hangs indefinitely, as this method also attempts to acquire the listeners_mutex.

Fix:

In the stop method of interpipesrc, if block mode was enabled, send a EOS signal to the internal appsrc to unblock any ongoing buffer push, and also return immediately to any other push with GST_FLOW_FLUSHING.

How to reproduce:

```
gstd &

gst-client-1.0 pipeline_create src videotestsrc ! video/x-raw,framerate=60/1,width=1920,height=1080 ! imxvpuenc_h264 name=enc5 bitrate=5000 ! h264parse ! video/x-h264,stream-format=avc ! queue name=q6 ! interpipesink name=ips sync=false async=false

gst-client-1.0 pipeline_create sink interpipesrc listen-to=ips is-live=true block=true allow-renegotiation=true stream-sync=1 ! video/x-h264,stream-format=avc ! fakesink

gst-client-1.0 pipeline_play src 
sleep 1

gst-client-1.0 pipeline_play sink

sleep 5

// This is the call that hangs
gst-client-1.0 pipeline_stop sink

gst-client-1.0 pipeline_stop src
```

Example thread backtraces (using gdb on gstd)
```
Thread 30 is the thread attempting to stop, thread 34 is the one pushing buffers 

Thread 34 (Thread 0xffff8672d0c0 (LWP 4120) "q6:src"):
#0  syscall () at ../sysdeps/unix/sysv/linux/aarch64/syscall.S:38
#1  0x0000ffff9663ef90 in g_cond_wait () from /lib64/libglib-2.0.so.0
#2  0x0000ffff87ec6d4c in ?? () from /lib64/libgstapp-1.0.so.0
#3  0x0000ffff940159fc in gst_inter_pipe_src_push_buffer (iface=0xffff5811fd70, buffer=0xffff7813a240, basetime=<optimized out>) at ../gst/interpipe/gstinterpipesrc.c:721
#4  0x0000ffff966074d4 in g_hash_table_foreach () from /lib64/libglib-2.0.so.0
#5  0x0000ffff94014138 in gst_inter_pipe_sink_process_sample (sink=sink@entry=0xffff58108e10, sample=0xffff8c128840) at ../gst/interpipe/gstinterpipesink.c:639
#6  0x0000ffff94014514 in gst_inter_pipe_sink_new_buffer (asink=0xffff58108e10, data=<optimized out>) at ../gst/interpipe/gstinterpipesink.c:655
#7  0x0000ffff87ecb20c in ?? () from /lib64/libgstapp-1.0.so.0
#8  0x0000ffff942c091c in gst_base_sink_chain_unlocked (basesink=basesink@entry=0xffff58108e10, obj=obj@entry=0xffff7813a240, is_list=is_list@entry=0, pad=<optimized out>) at ../libs/gst/base/gstbasesink.c:3959
#9  0x0000ffff942c1f08 in gst_base_sink_chain_main (basesink=0xffff58108e10, pad=<optimized out>, obj=0xffff7813a240, is_list=0) at ../libs/gst/base/gstbasesink.c:4093
#10 0x0000ffff967c1634 in gst_pad_chain_data_unchecked (pad=pad@entry=0xffff58109170, type=type@entry=4112, data=data@entry=0xffff7813a240) at ../gst/gstpad.c:4494
#11 0x0000ffff967c3344 in gst_pad_push_data (pad=pad@entry=0xffff74004ea0, type=type@entry=4112, data=data@entry=0xffff7813a240) at ../gst/gstpad.c:4770
#12 0x0000ffff967c8f6c in gst_pad_push (pad=0xffff74004ea0, buffer=buffer@entry=0xffff7813a240) at ../gst/gstpad.c:4889
#13 0x0000ffff87f114b4 in gst_queue_push_one (queue=0xffff8c108300) at ../plugins/elements/gstqueue.c:1436
#14 gst_queue_loop (pad=<optimized out>) at ../plugins/elements/gstqueue.c:1589
#15 0x0000ffff967ec0b4 in gst_task_func (task=0xaaaaf19546c0) at ../gst/gsttask.c:399
#16 0x0000ffff9663f974 in ?? () from /lib64/libglib-2.0.so.0
#17 0x0000ffff9663f558 in ?? () from /lib64/libglib-2.0.so.0
#18 0x0000ffff964d3ac4 in start_thread (arg=0x0) at pthread_create.c:448
#19 0x0000ffff9652374c in thread_start () at ../sysdeps/unix/sysv/linux/aarch64/clone3.S:76

Thread 30 (Thread 0xffff6dfbf0c0 (LWP 4078) "q6:src"):
#0  syscall () at ../sysdeps/unix/sysv/linux/aarch64/syscall.S:38
#1  0x0000ffff9663e300 in ?? () from /lib64/libglib-2.0.so.0
#2  0x0000ffff94015ca4 in gst_inter_pipe_src_stop (base=0xffff5811fd70) at ../gst/interpipe/gstinterpipesrc.c:434
#3  0x0000ffff942c6388 in gst_base_src_stop (basesrc=basesrc@entry=0xffff5811fd70) at ../libs/gst/base/gstbasesrc.c:3806
#4  0x0000ffff942c9134 in gst_base_src_activate_push (pad=0xffff581200a0, active=0, parent=0xffff5811fd70) at ../libs/gst/base/gstbasesrc.c:3961
#5  gst_base_src_activate_mode (pad=0xffff581200a0, parent=0xffff5811fd70, mode=GST_PAD_MODE_PUSH, active=0) at ../libs/gst/base/gstbasesrc.c:4033
#6  0x0000ffff967c622c in activate_mode_internal (pad=pad@entry=0xffff581200a0, parent=parent@entry=0xffff5811fd70, mode=mode@entry=GST_PAD_MODE_PUSH, active=active@entry=0) at ../gst/gstpad.c:1224
#7  0x0000ffff967c6540 in gst_pad_set_active (pad=pad@entry=0xffff581200a0, active=0) at ../gst/gstpad.c:1122
#8  0x0000ffff967a8b8c in activate_pads (vpad=<optimized out>, ret=0xffff6dfbdc00, active=0xffff6dfbdc9c) at ../gst/gstelement.c:3189
#9  0x0000ffff967b9058 in gst_iterator_fold (it=it@entry=0xffff5810b540, func=func@entry=0xffff967a8b64 <activate_pads>, ret=ret@entry=0xffff6dfbdc00, user_data=user_data@entry=0xffff6dfbdc9c) at ../gst/gstiterator.c:619
#10 0x0000ffff967a918c in iterator_activate_fold_with_resync (iter=iter@entry=0xffff5810b540, user_data=user_data@entry=0xffff6dfbdc9c, func=<optimized out>) at ../gst/gstelement.c:3213
#11 0x0000ffff967aa4a4 in gst_element_pads_activate (element=element@entry=0xffff5811fd70, active=<optimized out>, active@entry=0) at ../gst/gstelement.c:3249
#12 0x0000ffff967aa73c in gst_element_change_state_func (element=0xffff5811fd70, transition=GST_STATE_CHANGE_PAUSED_TO_READY) at ../gst/gstelement.c:3323
#13 0x0000ffff942c7444 in gst_base_src_change_state (element=0xffff5811fd70, transition=GST_STATE_CHANGE_PAUSED_TO_READY) at ../libs/gst/base/gstbasesrc.c:4071
#14 0x0000ffff967ac030 in gst_element_change_state (element=element@entry=0xffff5811fd70, transition=transition@entry=GST_STATE_CHANGE_PAUSED_TO_READY) at ../gst/gstelement.c:3101
#15 0x0000ffff967ac624 in gst_element_set_state_func (element=0xffff5811fd70, state=<optimized out>) at ../gst/gstelement.c:3055
#16 0x0000ffff96792484 in gst_bin_element_set_state (next=GST_STATE_READY, current=GST_STATE_PAUSED, start_time=0, base_time=8282398620118, element=0xffff5811fd70, bin=0xffff7811f370) at ../gst/gstbin.c:2582
```

