### PR TITLE
Forward context queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,5 @@ docs/plugins/sgml.stamp
 docs/plugins/xml/
 docs/version.entities
 docs/plugins/inspect-registry.xml
+
+.idea/

--- a/gst/interpipe/gstinterpipeilistener.c
+++ b/gst/interpipe/gstinterpipeilistener.c
@@ -143,6 +143,21 @@ gst_inter_pipe_ilistener_push_event (GstInterPipeIListener * self,
 }
 
 gboolean
+gst_inter_pipe_ilistener_query (GstInterPipeIListener * self, GstQuery * query)
+{
+  GstInterPipeIListenerInterface *iface;
+
+  g_return_val_if_fail (GST_INTER_PIPE_IS_ILISTENER (self), FALSE);
+  g_return_val_if_fail (query, FALSE);
+
+  iface = GST_INTER_PIPE_ILISTENER_GET_IFACE (self);
+  g_return_val_if_fail (iface->query != NULL, FALSE);
+
+  return iface->query (self, query);
+}
+
+
+gboolean
 gst_inter_pipe_ilistener_send_eos (GstInterPipeIListener * self)
 {
   GstInterPipeIListenerInterface *iface;

--- a/gst/interpipe/gstinterpipeilistener.h
+++ b/gst/interpipe/gstinterpipeilistener.h
@@ -94,6 +94,7 @@ struct _GstInterPipeIListenerInterface
   gboolean (* node_removed) (GstInterPipeIListener *iface, const gchar *node_removed);
   gboolean (* push_buffer) (GstInterPipeIListener *iface, GstBuffer *buffer, guint64 basetime);
   gboolean (* push_event) (GstInterPipeIListener *iface, GstEvent *event, guint64 basetime);
+  gboolean (* query) (GstInterPipeIListener *iface, GstQuery *query);
   gboolean (* send_eos) (GstInterPipeIListener *iface);
 };
 
@@ -192,6 +193,19 @@ gboolean gst_inter_pipe_ilistener_push_buffer (GstInterPipeIListener *iface,
  */
 gboolean gst_inter_pipe_ilistener_push_event (GstInterPipeIListener *iface,
 					      GstEvent *event, guint64 basetime);
+
+
+/**
+ * gst_inter_pipe_ilistener_query:
+ * @iface: (transfer none)(not nullable): The object that should query the #GstQuery downstream.
+ * @event: (transfer full)(not nullable): The #GstQuery to be pushed downstream.
+ *
+ * Ask @query to the downstream element. 
+ *
+ * Return: True if the query was successful, False otherwise.
+ */
+gboolean gst_inter_pipe_ilistener_query (GstInterPipeIListener *iface,
+					 GstQuery *query);
 
 /**
  * gst_inter_pipe_ilistener_send_eos:

--- a/gst/interpipe/gstinterpipeinode.c
+++ b/gst/interpipe/gstinterpipeinode.c
@@ -34,14 +34,14 @@
 G_DEFINE_INTERFACE (GstInterPipeINode, gst_inter_pipe_inode, G_TYPE_OBJECT);
 
 static void
-gst_inter_pipe_inode_default_init (GstInterPipeINodeInterface * iface)
+gst_inter_pipe_inode_default_init (GstInterPipeINodeInterface *iface)
 {
   //NOP
 }
 
 gboolean
-gst_inter_pipe_inode_add_listener (GstInterPipeINode * self,
-    GstInterPipeIListener * listener)
+gst_inter_pipe_inode_add_listener (GstInterPipeINode *self,
+    GstInterPipeIListener *listener)
 {
   GstInterPipeINodeInterface *iface;
 
@@ -54,8 +54,8 @@ gst_inter_pipe_inode_add_listener (GstInterPipeINode * self,
 }
 
 gboolean
-gst_inter_pipe_inode_remove_listener (GstInterPipeINode * self,
-    GstInterPipeIListener * listener)
+gst_inter_pipe_inode_remove_listener (GstInterPipeINode *self,
+    GstInterPipeIListener *listener)
 {
   GstInterPipeINodeInterface *iface;
 
@@ -68,7 +68,7 @@ gst_inter_pipe_inode_remove_listener (GstInterPipeINode * self,
 }
 
 gboolean
-gst_inter_pipe_inode_receive_event (GstInterPipeINode * self, GstEvent * event)
+gst_inter_pipe_inode_receive_event (GstInterPipeINode *self, GstEvent *event)
 {
   GstInterPipeINodeInterface *iface;
 
@@ -78,4 +78,15 @@ gst_inter_pipe_inode_receive_event (GstInterPipeINode * self, GstEvent * event)
   g_return_val_if_fail (iface->receive_event != NULL, FALSE);
 
   return iface->receive_event (self, event);
+}
+
+gboolean
+gst_inter_pipe_inode_send_query (GstInterPipeINode *self, GstQuery *query)
+{
+  g_return_val_if_fail (GST_INTER_PIPE_IS_INODE (self), FALSE);
+  g_return_val_if_fail (GST_IS_QUERY (query), FALSE);
+
+  GstInterPipeINodeInterface *iface = GST_INTER_PIPE_INODE_GET_IFACE (self);
+  g_return_val_if_fail (iface->query != NULL, FALSE);
+  return iface->query (self, query);
 }

--- a/gst/interpipe/gstinterpipeinode.h
+++ b/gst/interpipe/gstinterpipeinode.h
@@ -65,6 +65,7 @@ struct _GstInterPipeINodeInterface
   gboolean (* add_listener) (GstInterPipeINode *iface, GstInterPipeIListener * listener);
   gboolean (* remove_listener) (GstInterPipeINode *iface, GstInterPipeIListener * listener);
   gboolean (* receive_event) (GstInterPipeINode *iface, GstEvent *event);
+  gboolean (* query) (GstInterPipeINode *iface, GstQuery *query);
 };
 
 /**
@@ -105,6 +106,8 @@ gboolean gst_inter_pipe_inode_remove_listener (GstInterPipeINode *iface, GstInte
 gboolean gst_inter_pipe_inode_receive_event (GstInterPipeINode *iface, GstEvent *event);
 
 GType gst_inter_pipe_inode_get_type (void);
+
+gboolean gst_inter_pipe_inode_send_query (GstInterPipeINode *iface, GstQuery *query);
 
 G_END_DECLS
 

--- a/gst/interpipe/gstinterpipesink.c
+++ b/gst/interpipe/gstinterpipesink.c
@@ -82,6 +82,8 @@ static gboolean gst_inter_pipe_sink_set_caps (GstBaseSink * base,
     GstCaps * filter);
 static gboolean gst_inter_pipe_sink_event (GstBaseSink * base,
     GstEvent * event);
+static gboolean gst_inter_pipe_sink_propose_allocation (GstBaseSink * base,
+    GstQuery * query);
 static gboolean gst_inter_pipe_sink_are_caps_compatible (GstInterPipeSink *
     sink, GstCaps * listener_caps, GstCaps * sinkcaps);
 static GstCaps *gst_inter_pipe_sink_caps_intersect (GstCaps * caps1,
@@ -174,7 +176,8 @@ gst_inter_pipe_sink_class_init (GstInterPipeSinkClass * klass)
   basesink_class->get_caps = GST_DEBUG_FUNCPTR (gst_inter_pipe_sink_get_caps);
   basesink_class->set_caps = GST_DEBUG_FUNCPTR (gst_inter_pipe_sink_set_caps);
   basesink_class->event = GST_DEBUG_FUNCPTR (gst_inter_pipe_sink_event);
-
+  basesink_class->propose_allocation =
+      GST_DEBUG_FUNCPTR (gst_inter_pipe_sink_propose_allocation);
 }
 
 static void
@@ -596,6 +599,228 @@ gst_inter_pipe_sink_event (GstBaseSink * base, GstEvent * event)
   g_mutex_unlock (&sink->listeners_mutex);
   return GST_BASE_SINK_CLASS (gst_inter_pipe_sink_parent_class)->event (base,
       event);
+}
+
+
+struct AllocQueryCtx
+{
+  GstInterPipeSink *sink;
+  GstQuery *query;
+  GstAllocationParams params;
+  guint size;
+  guint min_buffers;
+  gboolean first_query;
+  guint num_listeners;
+};
+
+
+static gboolean
+gst_inter_pipe_sink_forward_query_allocation (gpointer key, gpointer data,
+    gpointer user_data)
+{
+  struct AllocQueryCtx *ctx;
+  GstInterPipeIListener *listener;
+  gchar *listener_name;
+  GstInterPipeSink *sink;
+  GstQuery *query;
+  GstCaps *caps;
+  gboolean ret = TRUE;
+  guint count, i, size, min;
+
+  listener = GST_INTER_PIPE_ILISTENER (data);
+  listener_name = (gchar *) key;
+  ctx = user_data;
+  sink = ctx->sink;
+
+  GST_DEBUG_OBJECT (sink, "Aggregating allocation from listener %s",
+      listener_name);
+
+  gst_query_parse_allocation (ctx->query, &caps, NULL);
+
+  query = gst_query_new_allocation (caps, FALSE);
+  if (!gst_inter_pipe_ilistener_query (listener, query)) {
+    GST_DEBUG_OBJECT (sink,
+        "Allocation query failed on listener %s, ignoring allocation",
+        listener_name);
+    ret = FALSE;
+    goto out;
+  }
+
+  /* Allocation Filter, extract of code from tee element */
+
+  /* Allocation Params:
+   * store the maximum alignment, prefix and padding, but ignore the
+   * allocators and the flags which are tied to downstream allocation*/
+  count = gst_query_get_n_allocation_params (query);
+  for (i = 0; i < count; i++) {
+    GstAllocationParams params = { 0, };
+
+    gst_query_parse_nth_allocation_param (query, i, NULL, &params);
+
+    GST_DEBUG_OBJECT (sink, "Aggregating AllocationParams align=%"
+        G_GSIZE_FORMAT " prefix=%" G_GSIZE_FORMAT " padding=%"
+        G_GSIZE_FORMAT, params.align, params.prefix, params.padding);
+
+    if (ctx->params.align < params.align)
+      ctx->params.align = params.align;
+
+    if (ctx->params.prefix < params.prefix)
+      ctx->params.prefix = params.prefix;
+
+    if (ctx->params.padding < params.padding)
+      ctx->params.padding = params.padding;
+  }
+
+  /* Allocation Pool:
+   * We want to keep the biggest size and biggest minimum number of buffers to
+   * make sure downstream requirement can be satisfied. We don't really care
+   * about the maximum, as this is a parameter of the downstream provided
+   * pool. We only read the first allocation pool as the minimum number of
+   * buffers is normally constant regardless of the pool being used. */
+  if (gst_query_get_n_allocation_pools (query) > 0) {
+    gst_query_parse_nth_allocation_pool (query, 0, NULL, &size, &min, NULL);
+
+    GST_DEBUG_OBJECT (sink,
+        "Aggregating allocation pool size=%u min_buffers=%u", size, min);
+
+    if (ctx->size < size)
+      ctx->size = size;
+
+    if (ctx->min_buffers < min)
+      ctx->min_buffers = min;
+  }
+
+  /* Allocation Meta:
+   * For allocation meta, we'll need to aggregate the argument using the new
+   * GstMetaInfo::agggregate_func */
+  count = gst_query_get_n_allocation_metas (query);
+  for (i = 0; i < count; i++) {
+    guint ctx_index;
+    GType api;
+    const GstStructure *param;
+
+    api = gst_query_parse_nth_allocation_meta (query, i, &param);
+
+    /* For the first query, copy all metas */
+    if (ctx->first_query) {
+      gst_query_add_allocation_meta (ctx->query, api, param);
+      continue;
+    }
+
+    /* Afterward, aggregate the common params */
+    if (gst_query_find_allocation_meta (ctx->query, api, &ctx_index)) {
+      const GstStructure *ctx_param;
+
+      gst_query_parse_nth_allocation_meta (ctx->query, ctx_index, &ctx_param);
+
+      /* Keep meta which has no params */
+      if (ctx_param == NULL && param == NULL)
+        continue;
+
+      GST_DEBUG_OBJECT (sink, "Dropping allocation meta %s", g_type_name (api));
+      gst_query_remove_nth_allocation_meta (ctx->query, ctx_index);
+    }
+  }
+
+  /* Finally, cleanup metas from the stored query that aren't support on this
+   * listener. */
+  count = gst_query_get_n_allocation_metas (ctx->query);
+  for (i = 0; i < count;) {
+    GType api = gst_query_parse_nth_allocation_meta (ctx->query, i, NULL);
+
+    if (!gst_query_find_allocation_meta (query, api, NULL)) {
+      GST_DEBUG_OBJECT (sink, "Dropping allocation meta %s", g_type_name (api));
+      gst_query_remove_nth_allocation_meta (ctx->query, i);
+      count--;
+      continue;
+    }
+
+    i++;
+  }
+
+  ctx->first_query = FALSE;
+  ctx->num_listeners++;
+
+out:
+  gst_query_unref (query);
+  return ret;
+}
+
+static gboolean
+gst_inter_pipe_sink_propose_allocation (GstBaseSink * base, GstQuery * query)
+{
+  struct AllocQueryCtx ctx = { 0 };
+  GstInterPipeSink *sink;
+  GHashTable *listeners;
+  GHashTableIter iter;
+  gboolean ret = TRUE;
+  gpointer key, value;
+
+  sink = GST_INTER_PIPE_SINK (base);
+
+  g_mutex_lock (&sink->listeners_mutex);
+  listeners = GST_INTER_PIPE_SINK_LISTENERS (sink);
+
+  ctx.sink = sink;
+  ctx.query = query;
+  ctx.first_query = TRUE;
+  gst_allocation_params_init (&ctx.params);
+
+  g_hash_table_iter_init (&iter, listeners);
+
+  while (g_hash_table_iter_next (&iter, &key, &value)) {
+    ret |= gst_inter_pipe_sink_forward_query_allocation (key, value, &ctx);
+  }
+
+  if (ret) {
+    guint count = gst_query_get_n_allocation_metas (query);
+    guint i;
+
+    GST_DEBUG_OBJECT (sink,
+        "Final allocation parameters: align=%" G_GSIZE_FORMAT " prefix=%"
+        G_GSIZE_FORMAT " padding %" G_GSIZE_FORMAT, ctx.params.align,
+        ctx.params.prefix, ctx.params.padding);
+
+    GST_DEBUG_OBJECT (sink, "Final allocation pools: size=%u  min_buffers=%u",
+        ctx.size, ctx.min_buffers);
+
+    GST_DEBUG_OBJECT (sink, "Final %u allocation meta:", count);
+
+    for (i = 0; i < count; i++) {
+      GST_DEBUG_OBJECT (sink, "    + aggregated allocation meta %s",
+          g_type_name (gst_query_parse_nth_allocation_meta (ctx.query, i,
+                  NULL)));
+    }
+
+    /* Allocate one more buffers when multiplexing so we don't starve the
+     * downstream threads. */
+    if (ctx.num_listeners > 1)
+      ctx.min_buffers++;
+
+    /* Check that we actually have parameters besides the defaults. */
+    if (ctx.params.align || ctx.params.prefix || ctx.params.padding) {
+      gst_query_add_allocation_param (ctx.query, NULL, &ctx.params);
+    }
+
+    /* When size == 0, buffers created from this pool would have no memory
+     * allocated. */
+    if (ctx.size) {
+      gst_query_add_allocation_pool (ctx.query, NULL, ctx.size,
+          ctx.min_buffers, 0);
+    }
+
+  } else {
+    guint count = gst_query_get_n_allocation_metas (query);
+    guint i;
+
+    for (i = 1; i <= count; i++) {
+      gst_query_remove_nth_allocation_meta (query, count - i);
+    }
+  }
+
+  g_mutex_unlock (&sink->listeners_mutex);
+
+  return ret;
 }
 
 /* Appsink Callbacks */

--- a/gst/interpipe/gstinterpipesrc.c
+++ b/gst/interpipe/gstinterpipesrc.c
@@ -87,6 +87,8 @@ static gboolean gst_inter_pipe_src_push_buffer (GstInterPipeIListener * iface,
 static gboolean gst_inter_pipe_src_push_event (GstInterPipeIListener * iface,
     GstEvent * event, guint64 basetime);
 static gboolean gst_inter_pipe_src_send_eos (GstInterPipeIListener * iface);
+static gboolean gst_inter_pipe_src_push_query (GstInterPipeIListener * iface,
+    GstQuery * query);
 static gboolean gst_inter_pipe_src_listen_node (GstInterPipeSrc * src,
     const gchar * node_name);
 static gboolean gst_inter_pipe_src_start (GstBaseSrc * base);
@@ -521,6 +523,7 @@ gst_inter_pipe_ilistener_init (GstInterPipeIListenerInterface * iface)
   iface->set_caps = gst_inter_pipe_src_set_caps;
   iface->push_buffer = gst_inter_pipe_src_push_buffer;
   iface->push_event = gst_inter_pipe_src_push_event;
+  iface->query = gst_inter_pipe_src_push_query;
   iface->send_eos = gst_inter_pipe_src_send_eos;
 }
 
@@ -756,6 +759,7 @@ no_events:
   }
 }
 
+
 static gboolean
 gst_inter_pipe_src_send_eos (GstInterPipeIListener * iface)
 {
@@ -774,6 +778,33 @@ gst_inter_pipe_src_send_eos (GstInterPipeIListener * iface)
   }
   return TRUE;
 }
+
+
+static gboolean
+gst_inter_pipe_src_push_query (GstInterPipeIListener * iface, GstQuery * query)
+{
+  GstInterPipeSrc *src;
+  GstPad *srcpad;
+  GstPad *peerpad;
+  gboolean ret = TRUE;
+
+  src = GST_INTER_PIPE_SRC (iface);
+  srcpad = GST_INTER_PIPE_SRC_PAD (GST_APP_SRC (src));
+
+  peerpad = gst_pad_get_peer (srcpad);
+  if (!peerpad) {
+    ret = FALSE;
+    goto out;
+  }
+
+  ret = gst_pad_query (peerpad, query);
+
+  gst_object_unref (peerpad);
+
+out:
+  return ret;
+}
+
 
 static gboolean
 gst_inter_pipe_src_listen_node (GstInterPipeSrc * src, const gchar * node_name)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,6 +1,6 @@
 # Feature options
 option('tests', type : 'feature', value : 'auto', yield : true, description : 'Enable tests')
-option('enable-gtk-doc', type : 'boolean', value : true, description : 'Use gtk-doc to build documentation')
+option('enable-gtk-doc', type : 'boolean', value : false, description : 'Use gtk-doc to build documentation')
 
 # Common options
 option('package-name', type : 'string', yield : true,


### PR DESCRIPTION
Tried to implement sharing context (mostly aiming at CUDA) between pipelines, but I'm hitting a hard wall here. It seems that the `CONTEXT` query comes very early, before the two src/sink element can link to each other. The link seems to be done via setting the property `listen-to` in the sink element. 

My plan was to listen to the queries in `interpipesrc`, save them in a queue then, once connected to a sink, relay the queries upstream to `interpipesink`. If we get a hit we can get the `GstContext` from upstream. Now, the problem is that I'm not sure how to pass that context to the element that originally started the query. I've tried with 

```c
GST_DEBUG_OBJECT(src, "Sending have context message");
msg = gst_message_new_have_context(GST_OBJECT(src), context);
gst_element_post_message(GST_ELEMENT(src), msg);
```

but I end up with 

```
Got context from element 'nvh265enc0': gst.cuda.context=context, gst.cuda.context=(GstCudaContext)"\(GstCudaContext\)\ cudacontext2", cuda-device-id=(uint)0;
Got context from element 'interpipesrc0': gst.cuda.context=context, gst.cuda.context=(GstCudaContext)"\(GstCudaContext\)\ cudacontext0", cuda-device-id=(uint)0;
```

when running the following example pipeline:

```
gst-launch-1.0 waylanddisplaysrc ! 'video/x-raw(memory:CUDAMemory),width=1920,height=1080,framerate=60/1' ! interpipesink name=sink  interpipesrc listen-to=sink ! nvh265enc ! fakesink
```

Because `nvh265enc0` queries for the context before we've managed to connect `interpipesrc` and `interpipesink`, so it sends the NEED CONTEXT message and ultimately just creates a CUDA context. After that, there's no point in manually setting the pipeline element context since it's too late..
  
See for example: [gstcudabasetransform.c#L179-L197](https://github.com/GStreamer/gstreamer/blob/2dd1b4bf270995fd4dd6aa240cb51cfcdf3c71b8/subprojects/gst-plugins-bad/sys/nvcodec/gstcudabasetransform.c#L179-L197): by the time we set ask for context (and ultimately create one) `filter->stream` has already be assigned, so changing the context afterwards doesn't do anything..

I'm going to park this for now and try implementing what was suggested in https://github.com/RidgeRun/gst-interpipe/issues/111: managing the context from the "outside" directly in Wolf by listening to the `NEED`/`HAVE_CONTEXT` messages on both buses. 
     